### PR TITLE
Fix stale form values in setValues and reset

### DIFF
--- a/packages/formoid/src/index.ts
+++ b/packages/formoid/src/index.ts
@@ -1,11 +1,11 @@
 export * from "./Array";
 export * from "./Form";
 export * from "./Predicate";
+export type { UnknownRecord } from "./Record";
 export * from "./Result";
 export * from "./useCompositeForm";
 export * from "./useFieldArray";
 export * from "./useForm";
 export * as validator from "./validator";
+export type { Validator } from "./validator";
 export * from "./zod";
-
-export { Validator } from "./validator";

--- a/packages/formoid/src/useFieldArrayState.ts
+++ b/packages/formoid/src/useFieldArrayState.ts
@@ -15,7 +15,7 @@ import { UnknownRecord, forEach } from "./Record";
 
 export function useFieldArrayState<T extends UnknownRecord>(initialValues: Array<T>) {
   const persistentInitialValues = useRef(initialValues);
-  const [state, setState] = useState(persistentInitialValues.current.map(initializeForm));
+  const [state, setState] = useState(() => persistentInitialValues.current.map(initializeForm));
 
   const errors = useMemo(() => state.map(getErrors), [state]);
   const values = useMemo(() => state.map(getValues), [state]);

--- a/packages/formoid/src/useFieldArrayState.ts
+++ b/packages/formoid/src/useFieldArrayState.ts
@@ -38,12 +38,9 @@ export function useFieldArrayState<T extends UnknownRecord>(initialValues: Array
   const remove = useCallback((index: number) => {
     setState(deleteAt(index));
   }, []);
-  const reset = useCallback(
-    (update?: Update<Array<T>>) => {
-      setState((update?.(values) ?? persistentInitialValues.current).map(initializeForm));
-    },
-    [values],
-  );
+  const reset = useCallback((update?: Update<Array<T>>) => {
+    setState((state) => (update?.(state.map(getValues)) ?? persistentInitialValues.current).map(initializeForm));
+  }, []);
   const setErrors: SetFieldArrayErrors<T> = useCallback((index, key, errors) => {
     setState(modifyAt(index, (group) => formStateManager(group).setErrors(key, errors)));
   }, []);

--- a/packages/formoid/src/useFormState.ts
+++ b/packages/formoid/src/useFormState.ts
@@ -31,21 +31,15 @@ export function useFormState<T extends UnknownRecord>(initialValues: T) {
   const enable = useCallback(<K extends keyof T>(key: K) => {
     setState((state) => formStateManager(state).enable(key));
   }, []);
-  const reset = useCallback(
-    (update?: Update<T>): void => {
-      setState(initializeForm(update ? update(values) : persistentInitialValues.current));
-    },
-    [values],
-  );
+  const reset = useCallback((update?: Update<T>): void => {
+    setState((state) => initializeForm(update ? update(getValues(state)) : persistentInitialValues.current));
+  }, []);
   const setErrors: SetErrors<T> = useCallback((key, errors): void => {
     setState((state) => formStateManager(state).setErrors(key, errors));
   }, []);
-  const setValues = useCallback(
-    (update: Update<T>): void => {
-      setState((state) => updateValues(state, update(values)));
-    },
-    [values],
-  );
+  const setValues = useCallback((update: Update<T>): void => {
+    setState((state) => updateValues(state, update(getValues(state))));
+  }, []);
 
   const toggle: Toggle = useCallback(
     (action) => forEach(values, (_, key) => (action === "enable" ? enable : disable)(key)),

--- a/packages/formoid/src/useFormState.ts
+++ b/packages/formoid/src/useFormState.ts
@@ -14,7 +14,7 @@ import { UnknownRecord, forEach } from "./Record";
 
 export function useFormState<T extends UnknownRecord>(initialValues: T) {
   const persistentInitialValues = useRef(initialValues);
-  const [state, setState] = useState(initializeForm(persistentInitialValues.current));
+  const [state, setState] = useState(() => initializeForm(persistentInitialValues.current));
 
   const errors = useMemo(() => getErrors(state), [state]);
   const values = useMemo(() => getValues(state), [state]);


### PR DESCRIPTION
Hello my friend. :slightly_smiling_face: 

I've found that doing two sequential form state updates like this:
- `fieldProps('...').onChange(value)`
- `setValues((values) => update(values))`

Will lose state change of the first update, since `setValues` close on useMemo'ed form `values`.

The only way to fix this in the userland is to wait for next `setValues` callback which would include changes done in the first step.
That would skip a frame and would be a bit sadge.

The fix avoids closing on useMemo'ed `values` by generating fresh `values` from `formState`. It's a bit wasteful, but a necessary evil if we don't want to change `formState` structure. :slightly_smiling_face: 